### PR TITLE
Updated fourier.py for latest PyTorch API

### DIFF
--- a/pysot/tracker/classifier/libs/fourier.py
+++ b/pysot/tracker/classifier/libs/fourier.py
@@ -21,14 +21,14 @@ def cfft2(a):
     """Do FFT and center the low frequency component.
     Always produces odd (full) output sizes."""
 
-    return rfftshift2(torch.rfft(a, 2))
+    return rfftshift2(torch.view_as_real(torch.fft.rfftn(a)))
 
 
 @tensor_operation
 def cifft2(a, signal_sizes=None):
     """Do inverse FFT corresponding to cfft2."""
 
-    return torch.irfft(irfftshift2(a), 2, signal_sizes=signal_sizes)
+    return torch.fft.irfftn(torch.view_as_complex(irfftshift2(a)), signal_sizes)
 
 
 @tensor_operation


### PR DESCRIPTION
torch.rfft  and torch.irfft are deprecated in the latest version of PyTorch. There were replaced with torch.fft.rfftn and torch.fft.irfftn respectively. The [PyTorch wiki](https://github.com/pytorch/pytorch/wiki/The-torch.fft-module-in-PyTorch-1.7) and [this thread](https://github.com/pytorch/pytorch/issues/49637) were useful resources for doing the conversion.